### PR TITLE
Clic 35 sale by company report graph

### DIFF
--- a/custom_reports/__manifest__.py
+++ b/custom_reports/__manifest__.py
@@ -28,6 +28,7 @@
         'demo/demo.xml',
     ],
     'qweb': [
+        'static/src/xml/sales_by_company_graph.xml',
         'static/src/xml/employee_performance_graph.xml',
         'static/src/xml/email_marketing_graph.xml',
         'static/src/xml/sales_statistics_graph.xml',

--- a/custom_reports/models/sales_by_company.py
+++ b/custom_reports/models/sales_by_company.py
@@ -17,7 +17,7 @@ class SalesByCompanyReport(models.Model):
     end_date = fields.Datetime(string='End Date')
     company_ids = fields.Many2many('res.company', relation='custom_reports_sales_by_company_report_rel', column1='custom_report_id', column2='company_id', string="companies")
     sales_by_company_ids = fields.One2many('custom_reports.sales_by_company', 'sales_by_company_report_id', string="Sales By Company")
-
+    sales_by_company_graph = fields.Text('Sales Graph', default = 'SalesGraph' )
     # methods
     # method for the creation of a new instance of a report
     @api.model

--- a/custom_reports/static/src/js/sales_by_company_graph.js
+++ b/custom_reports/static/src/js/sales_by_company_graph.js
@@ -1,0 +1,221 @@
+
+odoo.define('custom_reports.SalesByCompanyGraph', function(require)   {
+    'use strict';
+
+    var core = require('web.core');
+
+    var BasicFields = require('web.basic_fields');
+    var FieldRegistry = require('web.field_registry');
+
+    var COLORS = ['#875a7b', '#21b799', '#E4A900', '#D5653E', '#5B899E', '#E46F78', '#8F8F8F'];
+
+    var SalesByCompanyGraph = BasicFields.FieldText.extend({
+        jsLibs: [
+            '/web/static/lib/Chart/Chart.js',
+        ],
+        template: 'sales_by_company_graph_template',
+        xmlDependencies: ['custom_reports/static/src/xml/sales_by_company_graph.xml'],
+        
+        /**
+         * @override
+         */
+        init: function () {
+            this._super.apply(this, arguments);
+            this.graph_data = arguments[2].data.sales_by_company_ids.data;
+            this.graph_type = this.attrs.options.graph_type;
+        },
+
+        /**
+         * @override
+         */
+        start: function()   {
+            var self = this;
+            var labels = [];
+            var data = [];
+
+            self.graph_data.forEach(graph_datum =>  {
+                labels.push(graph_datum.data.company.data.display_name);
+                data.push(graph_datum.data.total_sales);
+            });
+
+            var colors = self._getColors(data.length);
+
+            switch (self.graph_type) {
+                case 'bar':
+                    self.config = self._getBarGraph(labels, data, colors);
+                    break;
+                // case 'line':
+                //     self.config = self._getLineGraph(labels, data, colors);
+                //     break;
+                case 'pie':
+                    self.config = self._getPieGraph(labels, data, colors);
+                    break;
+                case 'doughnut':
+                    self.config = self._getDoughnutGraph(labels, data, colors);
+                    break;
+                case 'polarArea':
+                    self.config = self._getPolarGraph(labels, data, colors);
+                    break;
+                case 'radar':
+                    self.config = self._getRadarGraph(labels, data, colors);
+                    break;
+            }
+            self._loadChart();
+        },
+
+        // ----------------------------
+        // Private
+        // ----------------------------
+
+        /**
+         * Returns a bar graph
+         * @private
+         */
+        _getBarGraph: function (labels, data, colors)   {
+            return {
+                type: 'bar',
+                data: {
+                   labels: labels,
+                   datasets: [{
+                       label: 'Sales by Company',
+                       data: data,
+                       backgroundColor: colors,
+                    }]
+                },
+            };
+        },
+
+        //  /**
+        //  * Returns a line graph
+        //  * @private
+        //  */
+        // _getLineGraph: function (labels, data, colors)   {
+        //     return {
+        //         type: 'line',
+        //         data: {
+        //            labels: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+        //            datasets: [{
+        //                label: 'ClickIt July Sale Ad',
+        //                data: [20, 22, 24, 27, 25, 44, 35, 27, 12, 8, 7],
+        //                borderColor: "#8e5ea2",
+        //                fill: false
+        //             },  {
+        //                 label: 'ClickIt August Sale Ad',
+        //                 data: [18, 20, 24, 29, 35, 37, 45, 50, 45, 40, 35],
+        //                 borderColor: "#3cba9f",
+        //                 fill: false
+
+        //             },  {
+        //                 label: 'ClickIt September Sale Ad',
+        //                 data: [27, 25, 29, 32, 30, 37, 55, 60, 65, 50, 30],
+        //                 borderColor: "#c45850",
+        //                 fill: false
+        //             },  {
+        //                 label: 'ClickIt October Sale Ad',
+        //                 data: [35, 29, 29, 32, 48, 50, 55, 60, 67, 70, 65],
+        //                 borderColor: "#3e95cd",
+        //                 fill: false
+        //             }]
+        //         },
+        //     };
+        // },
+
+        /**
+         * Returns a pie graph
+         * @private
+         */
+        _getPieGraph: function (labels, data, colors)   {
+            return {
+                type: 'pie',
+                data: {
+                   labels: labels,
+                   datasets: [{
+                       label: 'Sales by Company',
+                       data: data,
+                       backgroundColor: colors,
+                    }]
+                },
+            };
+        },
+
+        /**
+         * Returns a doughnut graph
+         * @private
+         */
+        _getDoughnutGraph: function (labels, data, colors)   {
+            return {
+                type: 'doughnut',
+                data: {
+                   labels: labels,
+                   datasets: [{
+                       label: 'Sales by Company',
+                       data: data,
+                       backgroundColor: colors,
+                    }]
+                },
+            };
+        },
+
+        /**
+         * Returns a polar graph
+         * @private
+         */
+        _getPolarGraph: function (labels, data, colors)   {
+            return {
+                type: 'polarArea',
+                data: {
+                   labels: labels,
+                   datasets: [{
+                       label: 'Sales by Company',
+                       data: data,
+                       backgroundColor: colors,
+                    }]
+                },
+            };
+        },
+
+        /**
+         * Returns a radar graph
+         * @private
+         */
+        _getRadarGraph: function (labels, data, colors)   {
+            return {
+                type: 'radar',
+                data: {
+                   labels: labels,
+                   datasets: [{
+                       label: 'Sales by Company',
+                       data: data,
+                       backgroundColor: colors,
+                    }]
+                },
+            };
+        },
+
+        /**
+         * Loads chart 
+         * @private
+         */
+        _loadChart: function()  {
+            var canvas = this.$('canvas')[0];
+            var context = canvas.getContext('2d');
+            return new Chart(context, this.config);
+        },
+
+        /**
+         * Returns an array of colors
+         * @private
+         */
+        _getColors: function(length)    {
+            var colors_array = COLORS;
+            while (colors_array.length < length)  {
+                colors_array.concat(colors_array);
+            }
+            return colors_array.slice(0, length);
+        },
+
+    });
+
+    FieldRegistry.add('sales_by_company_graph', SalesByCompanyGraph);
+
+});

--- a/custom_reports/static/src/js/sales_by_company_graph.js
+++ b/custom_reports/static/src/js/sales_by_company_graph.js
@@ -207,11 +207,11 @@ odoo.define('custom_reports.SalesByCompanyGraph', function(require)   {
          * @private
          */
         _getColors: function(length)    {
-            var colors_array = COLORS;
-            while (colors_array.length < length)  {
-                colors_array.concat(colors_array);
+            var bgColors = [];
+            for (var i = 0; i < length; i++)    {
+                bgColors.push(COLORS[i % COLORS.length]);
             }
-            return colors_array.slice(0, length);
+            return bgColors;
         },
 
     });

--- a/custom_reports/static/src/xml/sales_by_company_graph.xml
+++ b/custom_reports/static/src/xml/sales_by_company_graph.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<templates id="template" xml:space="preserve">
+   
+   <t t-name="sales_by_company_graph_template">
+      <div class="col-md-12" style="display: block !important;">
+			<canvas class="bar-chart" id="bar-chart" width="300" height="150" style="display:block !important;width:100%;"></canvas>
+		</div>
+   </t>
+
+</templates> 

--- a/custom_reports/views/assets.xml
+++ b/custom_reports/views/assets.xml
@@ -5,6 +5,7 @@
       <script type="text/javascript" src="/custom_reports/static/src/js/employee_performance_graph.js"/>
       <script type="text/javascript" src="/custom_reports/static/src/js/email_marketing_graph.js"/>
       <script type="text/javascript" src="/custom_reports/static/src/js/sales_statistics_graph.js"/>
+      <script type="text/javascript" src="/custom_reports/static/src/js/sales_by_company_graph.js"/>
       <link rel="stylesheet" type="text/scss" href="/custom_reports/static/src/scss/employee_performance_graph.scss"/>  
     </xpath>
   </template>

--- a/custom_reports/views/sales_by_company_reports_views.xml
+++ b/custom_reports/views/sales_by_company_reports_views.xml
@@ -107,17 +107,25 @@
                             </field>  
                             
                         </page>
-                        <page string="Graph">
-                            <field name="sales_by_company_ids">
-                                <pivot>
-                                    <field name="company_id" type="row"/>
-                                    <field name="total_sales" type="col"/>
-                                </pivot> 
-                            </field>
-                        </page>
                     </notebook>
                 </sheet>    
             </form>
         </field>
     </record>
+
+    <!-- sales by company graph form view -->
+    <record id="sales_by_company_report_view_form_graph" model="ir.ui.view">
+        <field name="name">Sales by Company Report Graph Form</field>
+        <field name="model">custom_reports.sales_by_company_report</field>
+        <field name="inherit_id" ref="custom_reports.sales_by_company_report_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Graph">
+                    <field name="sales_by_company_graph" widget="sales_by_company_graph"
+						title="Sales by Company" 
+						options="{'graph_type': 'pie'}"/>
+                </page>
+            </xpath>
+        </field>
+    </record> 
 </odoo>


### PR DESCRIPTION
Closes #28 

TASK OUTCOME

Task was completed as required by the corresponding issue.

As user, update **Custom Reports**. Go to Custom Reports -> **Custom Reports** (navbar) -> **Sales by Company**. Should be redirected to **Sales by Company**. Create a new Sales by Company Report by entering start date, end date, and selecting company.

On save, user should be able to view a pivot table with the sales for that company within the time range. As well as the newly added graphical representation of the data. 
